### PR TITLE
Add Steam App ID selection for Arma Reforger Server

### DIFF
--- a/src/components/ConfigForm.vue
+++ b/src/components/ConfigForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Server } from '../utils/interfaces';
 import FormTextInput from './FormTextInput.vue';
 import FormIpAddressInput from './FormIpAddressInput.vue';
@@ -17,6 +18,14 @@ const props = defineProps({ readonly: Boolean });
 const server = defineModel<Server>('server', { required: true });
 
 const inputViolationCounter = defineModel<number>('inputViolationCounter', { required: true });
+
+// Computed property to handle steamAppId as string for FormSelectInput
+const steamAppIdString = computed({
+    get: () => server.value.config.steamAppId.toString(),
+    set: (value: string) => {
+        server.value.config.steamAppId = parseInt(value);
+    }
+});
 
 function violIncr() {
     inputViolationCounter.value++;
@@ -51,6 +60,14 @@ function violDecr() {
             ></FormStartupParameterInput>
         </ul>
         <h3>Config</h3>
+        <FormSelectInput
+            :name="'Steam App Version'"
+            :tooltip="'Select between stable (1874900) and experimental (1890870) Arma Reforger Server versions'"
+            :options="['1874900', '1890870']"
+            :selectedIndex="server.config.steamAppId === 1874900 ? 0 : 1"
+            :readonly="props.readonly"
+            v-model="steamAppIdString"
+        ></FormSelectInput>
         <FormIpAddressInput
             :name="'bindAddress'"
             :tooltip="'default: 0.0.0.0'"

--- a/src/stores/servers.ts
+++ b/src/stores/servers.ts
@@ -138,7 +138,7 @@ export const useServersStore = defineStore('servers', {
             }
             return this.arsStatus;
         },
-        async recreateArsDockerImage(): Promise<boolean> {
+        async recreateArsDockerImage(): Promise<{ value: boolean; steamAppId: number }> {
             const result = await recreateArsDockerImage();
             return result;
         },

--- a/src/stores/servers.ts
+++ b/src/stores/servers.ts
@@ -14,6 +14,7 @@ import {
     getPublicIp,
     getArsStatus,
     recreateArsDockerImage,
+    recreateArsDockerImageWithSteamAppId,
     getPlayersFromLog,
     getKnownPlayers,
     getStats,
@@ -139,6 +140,10 @@ export const useServersStore = defineStore('servers', {
         },
         async recreateArsDockerImage(): Promise<boolean> {
             const result = await recreateArsDockerImage();
+            return result;
+        },
+        async recreateArsDockerImageWithSteamAppId(steamAppId: number): Promise<boolean> {
+            const result = await recreateArsDockerImageWithSteamAppId(steamAppId);
             return result;
         },
         async isRunningUpdate(uuid: string, isRunning: boolean): Promise<void> {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -181,3 +181,16 @@ export async function recreateArsDockerImage(): Promise<boolean> {
     logsStore.add(`ARS docker image recreation started`);
     return result.value;
 }
+
+export async function recreateArsDockerImageWithSteamAppId(steamAppId: number): Promise<boolean> {
+    const jsonResponse = await fetch(`${apiProtocol}://${api}/api/recreate-ars-docker-image`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ steamAppId }),
+        mode: 'cors'
+    });
+    const result = (await jsonResponse.json()) as Result;
+    const logsStore = useLogsStore();
+    logsStore.add(`ARS docker image recreation started with Steam App ID: ${steamAppId}`);
+    return result.value;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,6 +5,7 @@ import {
     ServerId,
     PlayerIdentityId,
     DockerStats,
+    DockerImageInfo,
     LogFile,
     ArsStatusResult,
     ArsStatus,
@@ -174,12 +175,49 @@ export async function getArsStatus(): Promise<ArsStatus> {
     return result.status;
 }
 
-export async function recreateArsDockerImage(): Promise<boolean> {
-    const jsonResponse = await fetch(`${apiProtocol}://${api}/api/recreate-ars-docker-image`);
-    const result = (await jsonResponse.json()) as Result;
+export async function recreateArsDockerImage(steamAppId?: number): Promise<{ value: boolean; steamAppId: number }> {
+    let jsonResponse: Response;
+    
+    if (steamAppId) {
+        // Use POST with body if steamAppId is provided
+        jsonResponse = await fetch(`${apiProtocol}://${api}/api/recreate-ars-docker-image`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ steamAppId }),
+        });
+    } else {
+        // Use GET if no steamAppId provided (uses current setting)
+        jsonResponse = await fetch(`${apiProtocol}://${api}/api/recreate-ars-docker-image`);
+    }
+    
+    const result = await jsonResponse.json();
     const logsStore = useLogsStore();
-    logsStore.add(`ARS docker image recreation started`);
-    return result.value;
+    logsStore.add(`ARS docker image recreation started with Steam App ID ${result.steamAppId || 'default'}`);
+    return result;
+}
+
+export async function getSteamAppIdInfo(): Promise<DockerImageInfo> {
+    const jsonResponse = await fetch(`${apiProtocol}://${api}/api/steam-app-id`);
+    const result = await jsonResponse.json() as DockerImageInfo;
+    const logsStore = useLogsStore();
+    logsStore.add(`Steam App ID info fetched`);
+    return result;
+}
+
+export async function setSteamAppId(steamAppId: number): Promise<{ value: boolean; steamAppId: number; info: DockerImageInfo }> {
+    const jsonResponse = await fetch(`${apiProtocol}://${api}/api/steam-app-id`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ steamAppId }),
+    });
+    const result = await jsonResponse.json();
+    const logsStore = useLogsStore();
+    logsStore.add(`Steam App ID set to ${steamAppId}`);
+    return result;
 }
 
 export async function recreateArsDockerImageWithSteamAppId(steamAppId: number): Promise<boolean> {

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -1,6 +1,7 @@
 import { Server, ServerConfig, StartupParameter } from './interfaces';
 
 export const defaultConfig: ServerConfig = {
+    steamAppId: 1874900,
     bindAddress: '0.0.0.0',
     bindPort: 2001,
     publicAddress: '',

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -182,3 +182,12 @@ export interface DockerStats {
     NetIO: string;
     PIDs: string;
 }
+
+export interface DockerImageInfo {
+    currentSteamAppId: number;
+    lastBuild?: {
+        steamAppId: number;
+        timestamp: number;
+    };
+    needsRebuild: boolean;
+}

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -88,6 +88,7 @@ export interface Server {
 }
 
 export interface ServerConfig {
+    steamAppId: number;
     bindAddress: string;
     bindPort: number;
     publicAddress: string;

--- a/src/utils/steam-app-versions.ts
+++ b/src/utils/steam-app-versions.ts
@@ -1,0 +1,24 @@
+// Steam App ID constants for Arma Reforger Server versions
+export const STEAM_APP_VERSIONS = {
+    STABLE: 1874900,
+    EXPERIMENTAL: 1890870
+} as const;
+
+export const STEAM_APP_VERSION_LABELS = {
+    [STEAM_APP_VERSIONS.STABLE]: 'Stable Arma Reforger Server',
+    [STEAM_APP_VERSIONS.EXPERIMENTAL]: 'Experimental Arma Reforger Server'
+} as const;
+
+export const STEAM_APP_VERSION_OPTIONS = [
+    { value: STEAM_APP_VERSIONS.STABLE.toString(), label: STEAM_APP_VERSION_LABELS[STEAM_APP_VERSIONS.STABLE] },
+    { value: STEAM_APP_VERSIONS.EXPERIMENTAL.toString(), label: STEAM_APP_VERSION_LABELS[STEAM_APP_VERSIONS.EXPERIMENTAL] }
+];
+
+// Helper functions
+export function getSteamAppVersionLabel(steamAppId: number): string {
+    return STEAM_APP_VERSION_LABELS[steamAppId as keyof typeof STEAM_APP_VERSION_LABELS] || `Unknown Version (${steamAppId})`;
+}
+
+export function isValidSteamAppId(steamAppId: number): boolean {
+    return steamAppId === STEAM_APP_VERSIONS.STABLE || steamAppId === STEAM_APP_VERSIONS.EXPERIMENTAL;
+}

--- a/src/views/ArsService.vue
+++ b/src/views/ArsService.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useServersStore } from '../stores/servers';
 import { ArsStatus } from '../utils/interfaces';
 import HostServerLog from '../components/HostServerLog.vue';
+import FormSelectInput from '../components/FormSelectInput.vue';
 
 const serversStore = useServersStore();
+const selectedSteamAppId = ref<string>('1874900');
 
 async function updateArsStatus() {
     const result = await serversStore.getArsStatus();
@@ -12,7 +14,8 @@ async function updateArsStatus() {
 }
 
 async function recreateArsDockerImage() {
-    await serversStore.recreateArsDockerImage();
+    const steamAppId = parseInt(selectedSteamAppId.value);
+    await serversStore.recreateArsDockerImageWithSteamAppId(steamAppId);
 }
 
 const arsStatus = computed<string>(() => {
@@ -29,6 +32,15 @@ updateArsStatus();
         <span class="result">{{ arsStatus }}</span>
     </div>
     <div>
+        <FormSelectInput
+            :name="'Steam App Version for Docker Image'"
+            :tooltip="'Select between stable (1874900) and experimental (1890870) Arma Reforger Server versions'"
+            :options="['1874900', '1890870']"
+            :selectedIndex="selectedSteamAppId === '1874900' ? 0 : 1"
+            :readonly="false"
+            v-model="selectedSteamAppId"
+        />
+        <br />
         <button
             class="form-input-button"
             type="button"


### PR DESCRIPTION
Introduces Steam App ID configuration to allow selection between stable and experimental Arma Reforger Server versions. Updates server config, UI forms, and API/store logic to support recreating the ARS Docker image with the chosen Steam App ID. Adds constants and helpers for Steam App versions.

needs this PR to work: https://github.com/gruppe-adler/arsa-backend/pull/30

edit flagged as draft due to errors on execution (param was not successfully transmitted fully)